### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://karunesh77.visualstudio.com/255f27f5-ac93-4c3e-bf31-8973b266460f/484440a5-60d4-4945-88e3-5f399d674ce2/_apis/work/boardbadge/a047b023-348e-4a80-951d-5b709801bbd9)](https://karunesh77.visualstudio.com/255f27f5-ac93-4c3e-bf31-8973b266460f/_boards/board/t/484440a5-60d4-4945-88e3-5f399d674ce2/Microsoft.RequirementCategory)
 # learnpytest


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://karunesh77.visualstudio.com/255f27f5-ac93-4c3e-bf31-8973b266460f/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.